### PR TITLE
Update README.md with callback requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ bot.init({verbose: false}, function (err) {
 
 ### Commands
 
-Anywhere we deal with callbacks functions (`cb`), expect them to pass `err` or, if appropriate, `err, result`.
+Anywhere we deal with callbacks functions (`cb`), you are required to supply this argument, and expect them to pass `err` or, if appropriate, `err, result`.
 
 #### `bot.init(options, cb)`
 


### PR DESCRIPTION
When using the package, I didn't know that the callback was a required argument and neglected to include it when calling `bot.init()` in a REPL session. This change tries to clarify that requirement.