### PR TITLE
Add a `deinit` bot method

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,12 @@
       "request": "launch",
       "name": "Launch Hello World",
       "program": "${workspaceFolder}/demos/hello_world.js"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Math Bot",
+      "program": "${workspaceFolder}/demos/math_bot.js"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -63,14 +63,17 @@ bot
 
 ### Commands
 
-
 Anywhere a promise is returned from the bot API, you should handle error with `.cathc(err => { ... })`
 
-#### `bot.init(options, cb)`
+#### `bot.init(options)`
 
 As shown above, this must be run to initialize a bot before using it. It checks to make sure you're properly logged into Keybase and gets basic info about your session. Afterwards, feel free to check bot.myInfo() to see or check who you're logged in as.
 
 `options` is a dictionary expecting `username` and `paperkey` (which are pretty self-explanatory), as well as `verbose`, which says whether the bot should log much of what it's doing.
+
+#### `bot.deinit()`
+
+This should be run to after your bot finishes running. It logs you out of your Keybase session.
 
 #### `bot.myInfo()`
 
@@ -90,7 +93,6 @@ lists your chats, with info on which ones have unread messages.
   fail_offline?: boolean,
 }
 ```
-
 
 #### `bot.chatSend(chatOptionsSend) : Promise`
 
@@ -153,6 +155,7 @@ Deletes a message in a channel. Messages have `messageId`'s associated with them
 Known bug: the GUI has a cache, and deleting from the CLI may not become apparent immediately.
 
 **Chat Options Delete**
+
 ```javascript
 // example options
 {
@@ -178,18 +181,23 @@ Example usage:
 ```javascript
 // reply to incoming traffic on all channels with 'thanks!'
 var onMessages = function(m) {
-  var channel  = m.channel
+  var channel = m.channel
   var messages = m.messages // we could look in this array to read them and write custom replies
-  bot.chatSend({
-    channel: channel,
-    message: {
-      body: 'thanks!!!'
+  bot.chatSend(
+    {
+      channel: channel,
+      message: {
+        body: 'thanks!!!',
+      },
+    },
+    function(err, res) {
+      if (err) {
+        console.log(err)
+      }
     }
-  }, function(err, res) {
-    if (err) {console.log(err);}
-  });
+  )
 }
-bot.watchAllChannelsForNewMessages({onMessages: onMessages});
+bot.watchAllChannelsForNewMessages({onMessages: onMessages})
 ```
 
 This function may take a few seconds to recognize new messages, as the current implementation polls. Soon we expose a realtime stream in the API.

--- a/README.md
+++ b/README.md
@@ -21,44 +21,27 @@ npm install keybase-chat-bot
 // Says hello to the keybase `kbot` account
 //
 
-const keybaseChatBot = require('keybase-chat-bot')
+const bot = new Bot()
 
-const bot = new keybaseChatBot.Bot()
-
-bot
-  .init({
-    username: process.env.KB_USERNAME,
-    paperkey: process.env.KB_PAPERKEY,
-    verbose: false,
-  })
-  .catch(err => console.log(err))
-  .then(() => {
-    console.log('Your bot is initialized. It is logged in as ' + bot.myInfo().username)
-
-    const channel = {
-      name: 'kbot,' + bot.myInfo().username,
-      public: false,
-      topic_type: 'chat',
-    }
-
-    const sendArg = {
-      channel: channel,
-      message: {
-        body:
-          'Hello kbot! This is ' +
-          bot.myInfo().username +
-          ' saying hello from my device ' +
-          bot.myInfo().devicename,
-      },
-    }
-
-    bot
-      .chatSend(sendArg)
-      .then(() => {
-        console.log('Message sent!')
-      })
-      .catch(err => console.log('Message failed to send', err))
-  })
+try {
+  await bot.init({username: process.env.KB_USERNAME, paperkey: process.env.KB_PAPERKEY, verbose: false})
+  console.log(`Your bot is initialized. It is logged in as ${bot.myInfo().username}`)
+  const channel = {name: 'kbot,' + bot.myInfo().username, public: false, topic_type: 'chat'}
+  const sendArg = {
+    channel: channel,
+    message: {
+      body: `Hello kbot! This is ${bot.myInfo().username} saying hello from my device ${
+        bot.myInfo().devicename
+      }`,
+    },
+  }
+  await bot.chatSend(sendArg)
+  console.log('Message sent!')
+} catch (error) {
+  console.error(error)
+} finally {
+  await bot.deinit()
+}
 ```
 
 ### Commands

--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ As shown above, this must be run to initialize a bot before using it. It checks 
 
 `options` is a dictionary expecting `username` and `paperkey` (which are pretty self-explanatory), as well as `verbose`, which says whether the bot should log much of what it's doing.
 
+**options**:
+
+```javascript
+{
+  username: string,
+  paperkey: string,
+  verbose?: boolean,
+}
+```
+
 #### `bot.deinit()`
 
 This should be run to after your bot finishes running. It logs you out of your Keybase session.
@@ -61,6 +71,15 @@ This should be run to after your bot finishes running. It logs you out of your K
 #### `bot.myInfo()`
 
 returns your username and devicename.
+
+**Return value**:
+
+```javascript
+{
+  username: string,
+  devicename: string,
+}
+```
 
 #### `bot.chatList(chatOptionsList) : Promise`
 

--- a/demos/check_for_unreads.js
+++ b/demos/check_for_unreads.js
@@ -1,24 +1,22 @@
 #!/usr/bin/env node
 const {Bot} = require('../index.js')
 
-const bot = new Bot()
+async function main() {
+  const bot = new Bot()
 
-bot
-  .init({
-    username: process.env.KB_USERNAME,
-    paperkey: process.env.KB_PAPERKEY,
-    verbose: false,
-  })
-  .then(() => {
-    bot
-      .chatList({
-        show_errors: true,
-        unread_only: true,
-      })
-      .then(res => {
-        const unreadCount = res.conversations.filter(c => c.unread).length
-        console.log(`You have ${unreadCount} unread conversations out of ${res.conversations.length} total`)
-      })
-      .catch(err => console.log(err))
-  })
-  .catch(err => console.log('Failed to initialize', err))
+  try {
+    await bot.init({username: process.env.KB_USERNAME, paperkey: process.env.KB_PAPERKEY, verbose: false})
+    const res = await bot.chatList({
+      show_errors: true,
+      unread_only: true,
+    })
+    const unreadCount = res.conversations.filter(c => c.unread).length
+    console.log(`You have ${unreadCount} unread conversations out of ${res.conversations.length} total`)
+  } catch (error) {
+    console.error(error)
+  } finally {
+    await bot.deinit()
+  }
+}
+
+main()

--- a/demos/hello_world.js
+++ b/demos/hello_world.js
@@ -35,5 +35,6 @@ bot
         console.log('Message sent!')
       })
       .catch(err => console.log('Message failed to send', err))
+      .finally(() => bot.deinit())
   })
   .catch(err => console.log(err))

--- a/demos/hello_world.js
+++ b/demos/hello_world.js
@@ -1,40 +1,28 @@
 #!/usr/bin/env node
 const {Bot} = require('../index.js')
 
-const bot = new Bot()
+async function main() {
+  const bot = new Bot()
 
-bot
-  .init({
-    username: process.env.KB_USERNAME,
-    paperkey: process.env.KB_PAPERKEY,
-    verbose: false,
-  })
-  .then(() => {
-    console.log('Your bot is initialized. It is logged in as ' + bot.myInfo().username)
-
-    const channel = {
-      name: 'kbot,' + bot.myInfo().username,
-      public: false,
-      topic_type: 'chat',
-    }
-
+  try {
+    await bot.init({username: process.env.KB_USERNAME, paperkey: process.env.KB_PAPERKEY, verbose: false})
+    console.log(`Your bot is initialized. It is logged in as ${bot.myInfo().username}`)
+    const channel = {name: 'kbot,' + bot.myInfo().username, public: false, topic_type: 'chat'}
     const sendArg = {
       channel: channel,
       message: {
-        body:
-          'Hello kbot! This is ' +
-          bot.myInfo().username +
-          ' saying hello from my device ' +
-          bot.myInfo().devicename,
+        body: `Hello kbot! This is ${bot.myInfo().username} saying hello from my device ${
+          bot.myInfo().devicename
+        }`,
       },
     }
+    await bot.chatSend(sendArg)
+    console.log('Message sent!')
+  } catch (error) {
+    console.error(error)
+  } finally {
+    await bot.deinit()
+  }
+}
 
-    bot
-      .chatSend(sendArg)
-      .then(() => {
-        console.log('Message sent!')
-      })
-      .catch(err => console.log('Message failed to send', err))
-      .finally(() => bot.deinit())
-  })
-  .catch(err => console.log(err))
+main()

--- a/demos/math_bot.js
+++ b/demos/math_bot.js
@@ -39,24 +39,32 @@ async function main() {
 
     const onMessages = async o => {
       for (const m of o.messages) {
-        const prefix = m.msg.content.text.body.slice(0, 6)
-        if (prefix === '/math ') {
-          const reply = {
-            body: msgReply(m.msg.content.text.body.slice(6)),
+        try {
+          if (m.msg.content.type === 'text') {
+            const prefix = m.msg.content.text.body.slice(0, 6)
+            if (prefix === '/math ') {
+              const reply = {
+                body: msgReply(m.msg.content.text.body.slice(6)),
+              }
+              await bot.chatSend({channel: o.channel, message: reply})
+            }
           }
-          await bot.chatSend({channel: o.channel, message: reply})
+        } catch (error) {
+          console.error(error)
         }
       }
     }
 
     console.log('Beginning watch for new messages.')
-    console.log('Tell anyone to send a message to ' + bot.myInfo().username + 'starting with `/math `')
-    bot.watchAllChannelsForNewMessages({onMessages})
+    console.log(`Tell anyone to send a message to ${bot.myInfo().username} starting with '/math '`)
+    await bot.watchAllChannelsForNewMessages({onMessages})
   } catch (error) {
     console.error(error)
-  } finally {
-    await bot.deinit()
   }
+
+  // finally {
+  //   await bot.deinit()
+  // }
 }
 
 main()

--- a/demos/math_bot.js
+++ b/demos/math_bot.js
@@ -11,8 +11,6 @@ const mathjs = require('mathjs')
 //          /math sqrt(pi/2) * 3!`
 //
 
-// -----------------------------------------------------------------------------
-
 const msgReply = function(s) {
   let a1, a2, ans, b1, b2, eqn
   try {
@@ -30,9 +28,9 @@ const msgReply = function(s) {
   return ans
 }
 
-async function main() {
-  const bot = new Bot()
+const bot = new Bot()
 
+async function main() {
   try {
     await bot.init({username: process.env.KB_USERNAME, paperkey: process.env.KB_PAPERKEY})
     console.log('I am me!', bot.myInfo().username, bot.myInfo().devicename)
@@ -61,10 +59,13 @@ async function main() {
   } catch (error) {
     console.error(error)
   }
-
-  // finally {
-  //   await bot.deinit()
-  // }
 }
+
+function shutDown() {
+  bot.deinit()
+}
+
+process.on('SIGINT', shutDown)
+process.on('SIGTERM', shutDown)
 
 main()

--- a/demos/math_bot.js
+++ b/demos/math_bot.js
@@ -61,8 +61,9 @@ async function main() {
   }
 }
 
-function shutDown() {
-  bot.deinit()
+async function shutDown() {
+  await bot.deinit()
+  process.exit()
 }
 
 process.on('SIGINT', shutDown)

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -61,7 +61,7 @@ class Bot {
   }
 
   deinit(): Promise<void> {
-    return keybaseExec({
+    keybaseExec({
       args: ['logout'],
     })
   }

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -60,6 +60,12 @@ class Bot {
     })
   }
 
+  deinit(): Promise<void> {
+    return keybaseExec({
+      args: ['logout'],
+    })
+  }
+
   // --------------------------------------------------------------------------
 
   chatList(options: ChatOptionsList): Promise<any> {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -21,8 +21,11 @@ type InitOptions = {|
   verbose?: boolean,
 |}
 
-// ============================================================================
-
+/**
+ * A Keybase bot.
+ *
+ * @class Bot
+ */
 class Bot {
   _dPair: ?DeviceUsernamePair
   _initialized: boolean
@@ -42,8 +45,13 @@ class Bot {
     this._gasPreserver = new GasPreserver()
   }
 
-  // --------------------------------------------------------------------------
-
+  /**
+   * Initializes a bot by logging in with the given credentials. This must be run before your bot can be used.
+   *
+   * @param {InitOptions} options – An object expecting `username` and `paperkey` (which are pretty self-explanatory), as well as `verbose`, which says whether the bot should log much of what it's doing.
+   * @returns {Promise<?string>}
+   * @memberof Bot
+   */
   init(options: InitOptions): Promise<?string> {
     this._verbose = options.verbose || false
 
@@ -60,6 +68,12 @@ class Bot {
     })
   }
 
+  /**
+   * Deinitializes a bot by logging it out of its current Keybase session. Should be run after your bot finishes.
+   *
+   * @returns {Promise<void>}
+   * @memberof Bot
+   */
   deinit(): Promise<void> {
     keybaseExec({
       args: ['logout'],

--- a/lib/full-watcher.js
+++ b/lib/full-watcher.js
@@ -83,7 +83,7 @@ class FullWatcher {
   // --------------------------------------------------------------------------
 
   _watchLoop(): void {
-    this._checkForNewMessagesInAllConversations.then(() => {
+    this._checkForNewMessagesInAllConversations().then(() => {
       const delay = this._bot._gasPreserver.recommendedWait()
       setTimeout(() => {
         this._loopCount++

--- a/lib/gas-preserver.js
+++ b/lib/gas-preserver.js
@@ -2,33 +2,32 @@
 import tweakables from './tweakables.js'
 
 class GasPreserver {
+  // --------------------------------------------------------------------------
+
+  _lastPassedGas: Array<any>
+  _currentWait: number
 
   // --------------------------------------------------------------------------
 
-  _lastPassedGas: Array<any>;
-  _currentWait: number;
-
-  // --------------------------------------------------------------------------
-
-  constructor () : void {
+  constructor(): void {
     this._lastPassedGas = []
     this._currentWait = tweakables.MIN_CHANNEL_WATCH_LOOP
   }
 
   // --------------------------------------------------------------------------
 
-  passGas (rateLimits: Array<any>) : void {
+  passGas(rateLimits: Array<any>): void {
     this._lastPassedGas.push(rateLimits[0]) // let's just take the first for now
     this._filterOldGas()
   }
 
   // --------------------------------------------------------------------------
 
-  recommendedWait () : number {
-    let speed = this._getCurrentSpeed()
-    let gas = this._getRemainingGas()
-    let gas_left_with_buffer = Math.max(0, gas - tweakables.TARGET_GAS_REMAINING)
-    let timeLeft = this._getTimeTillReset()
+  recommendedWait(): number {
+    const speed = this._getCurrentSpeed()
+    const gas = this._getRemainingGas()
+    const gas_left_with_buffer = Math.max(0, gas - tweakables.TARGET_GAS_REMAINING)
+    const timeLeft = this._getTimeTillReset()
     // this._currentWait = 1000 * (speed * timeLeft / gas) * tweakables.SAFETY_BUFFER
     if (speed * timeLeft > gas_left_with_buffer) {
       this._currentWait *= tweakables.GAS_ADJ_MULT
@@ -37,41 +36,44 @@ class GasPreserver {
     }
     this._currentWait = Math.max(tweakables.MIN_CHANNEL_WATCH_LOOP, this._currentWait)
     this._currentWait = Math.min(tweakables.MAX_CHANNEL_WATCH_LOOP, this._currentWait)
-    console.log(`...speed=${speed.toFixed(2)}, gas=${gas}, timeLeft=${timeLeft}, currentWait=${this._currentWait}, history=${this._lastPassedGas.length}`)
+    console.log(
+      `...speed=${speed.toFixed(2)}, gas=${gas}, timeLeft=${timeLeft}, currentWait=${
+        this._currentWait
+      }, history=${this._lastPassedGas.length}`
+    )
     return this._currentWait
   }
 
   // --------------------------------------------------------------------------
 
-  _filterOldGas () : void {
+  _filterOldGas(): void {
     let ind = 0
     // throw away any data before a reset
     for (ind = this._lastPassedGas.length - 2; ind >= 0; ind--) {
-      let latest = this._lastPassedGas[this._lastPassedGas.length - 1]
-      let curr = this._lastPassedGas[ind]
+      const latest = this._lastPassedGas[this._lastPassedGas.length - 1]
+      const curr = this._lastPassedGas[ind]
       if (curr.gas < latest.gas || curr.reset < latest.reset) {
         break
       }
     }
     if (ind >= 0) {
       console.log('BEFORE GAS CLEANUP', this._lastPassedGas)
-      this._lastPassedGas.splice(0, (ind + 1))
+      this._lastPassedGas.splice(0, ind + 1)
       console.log('AFTER GAS CLEANUP', this._lastPassedGas)
     }
     // now throw away anything over a certain age
     if (this._lastPassedGas.length > 2) {
-      let keepers = this._lastPassedGas.slice(-2)
+      const keepers = this._lastPassedGas.slice(-2)
       let candidates = this._lastPassedGas.slice(0, -2)
-      candidates = candidates.filter((c) => c.reset < keepers[1].reset + tweakables.GAS_MONITOR_WINDOW / 1000)
+      candidates = candidates.filter(c => c.reset < keepers[1].reset + tweakables.GAS_MONITOR_WINDOW / 1000)
       this._lastPassedGas = candidates.concat(keepers)
-      //console.log(this._lastPassedGas)
+      // console.log(this._lastPassedGas)
     }
-    return
   }
 
   // --------------------------------------------------------------------------
 
-  _getCurrentSpeed () : number {
+  _getCurrentSpeed(): number {
     if (this._lastPassedGas.length < 2) {
       return 1
     } else {
@@ -84,7 +86,7 @@ class GasPreserver {
 
   // --------------------------------------------------------------------------
 
-  _getRemainingGas () : number {
+  _getRemainingGas(): number {
     if (this._lastPassedGas.length < 1) {
       return tweakables.DEFAULT_GAS
     } else {
@@ -94,7 +96,7 @@ class GasPreserver {
 
   // --------------------------------------------------------------------------
 
-  _getTimeTillReset () : number {
+  _getTimeTillReset(): number {
     if (this._lastPassedGas.length < 1) {
       return tweakables.DEFAULT_TIME_LEFT
     } else {
@@ -103,7 +105,6 @@ class GasPreserver {
   }
 
   // --------------------------------------------------------------------------
-
 }
 
 export {GasPreserver}

--- a/lib/tweakables.js
+++ b/lib/tweakables.js
@@ -1,5 +1,5 @@
 // @flow
-let tweakables = {
+const tweakables = {
   MIN_CHANNEL_WATCH_LOOP: 1000,
   MAX_CHANNEL_WATCH_LOOP: 60000,
   DEFAULT_GAS: 500,


### PR DESCRIPTION
With the introduction of one-shot mode, there wasn't a way to log the bot out after `bot.init()` was run. I think the best solution to this problem is to add a `bot.deinit()` method that should be run at the end of every bot program.

Other changes:
- Added/changed documentation (both in readme and jsdoc) to reflect the `bot.deinit()` addition
- Added a VSCode debug task for math bot 🤖 
- Fixed some issues with math bot, but I think more rigorous testing is needed. I stop it from crashing, but I'm getting an issue where it's looking at all messages in a chat instead of just new ones. It seemed a little outside the scope of this PR, but would probably be something good to look at when we restructure the chat stuff as per #18 
- Changed the examples to use async/await, which I think fit the `deinit()` paradigm better. General bot usage now looks like:
```javascript
try {
  await bot.init({...})
  ....
} catch (error) {
  console.error(error)
} finally {
  bot.deinit()
}
```
- Assorted prettier/eslint autofixes