### PR TITLE
Pass paperkey via stdin

### DIFF
--- a/demos/hello_world.js
+++ b/demos/hello_world.js
@@ -3,58 +3,37 @@ const {Bot} = require('../index.js')
 
 const bot = new Bot()
 
-const readStdin = () => {
-  return new Promise((resolve, reject) => {
-    const stdin = []
-    let buf = null
-    process.stdin.on('data', chunk => {
-      stdin.push(chunk)
-    })
-
-    process.stdin.on('end', () => {
-      buf = Buffer.concat(stdin)
-      resolve(buf)
-    })
-
-    process.stdin.on('error', err => {
-      reject(err)
-    })
+bot
+  .init({
+    username: process.env.KB_USERNAME,
+    paperkey: process.env.KB_PAPERKEY,
+    verbose: false,
   })
-}
+  .then(() => {
+    console.log('Your bot is initialized. It is logged in as ' + bot.myInfo().username)
 
-readStdin().then(stdin => {
-  bot
-    .init({
-      username: process.env.KB_USERNAME,
-      paperkey: stdin,
-      verbose: false,
-    })
-    .then(() => {
-      console.log('Your bot is initialized. It is logged in as ' + bot.myInfo().username)
+    const channel = {
+      name: 'kbot,' + bot.myInfo().username,
+      public: false,
+      topic_type: 'chat',
+    }
 
-      const channel = {
-        name: 'kbot,' + bot.myInfo().username,
-        public: false,
-        topic_type: 'chat',
-      }
+    const sendArg = {
+      channel: channel,
+      message: {
+        body:
+          'Hello kbot! This is ' +
+          bot.myInfo().username +
+          ' saying hello from my device ' +
+          bot.myInfo().devicename,
+      },
+    }
 
-      const sendArg = {
-        channel: channel,
-        message: {
-          body:
-            'Hello kbot! This is ' +
-            bot.myInfo().username +
-            ' saying hello from my device ' +
-            bot.myInfo().devicename,
-        },
-      }
-
-      bot
-        .chatSend(sendArg)
-        .then(() => {
-          console.log('Message sent!')
-        })
-        .catch(err => console.log('Message failed to send', err))
-    })
-    .catch(err => console.log(err))
-})
+    bot
+      .chatSend(sendArg)
+      .then(() => {
+        console.log('Message sent!')
+      })
+      .catch(err => console.log('Message failed to send', err))
+  })
+  .catch(err => console.log(err))

--- a/demos/hello_world.js
+++ b/demos/hello_world.js
@@ -3,37 +3,58 @@ const {Bot} = require('../index.js')
 
 const bot = new Bot()
 
-bot
-  .init({
-    username: process.env.KB_USERNAME,
-    paperkey: process.env.KB_PAPERKEY,
-    verbose: false,
+const readStdin = () => {
+  return new Promise((resolve, reject) => {
+    const stdin = []
+    let buf = null
+    process.stdin.on('data', chunk => {
+      stdin.push(chunk)
+    })
+
+    process.stdin.on('end', () => {
+      buf = Buffer.concat(stdin)
+      resolve(buf)
+    })
+
+    process.stdin.on('error', err => {
+      reject(err)
+    })
   })
-  .then(() => {
-    console.log('Your bot is initialized. It is logged in as ' + bot.myInfo().username)
+}
 
-    const channel = {
-      name: 'kbot,' + bot.myInfo().username,
-      public: false,
-      topic_type: 'chat',
-    }
+readStdin().then(stdin => {
+  bot
+    .init({
+      username: process.env.KB_USERNAME,
+      paperkey: stdin,
+      verbose: false,
+    })
+    .then(() => {
+      console.log('Your bot is initialized. It is logged in as ' + bot.myInfo().username)
 
-    const sendArg = {
-      channel: channel,
-      message: {
-        body:
-          'Hello kbot! This is ' +
-          bot.myInfo().username +
-          ' saying hello from my device ' +
-          bot.myInfo().devicename,
-      },
-    }
+      const channel = {
+        name: 'kbot,' + bot.myInfo().username,
+        public: false,
+        topic_type: 'chat',
+      }
 
-    bot
-      .chatSend(sendArg)
-      .then(() => {
-        console.log('Message sent!')
-      })
-      .catch(err => console.log('Message failed to send', err))
-  })
-  .catch(err => console.log(err))
+      const sendArg = {
+        channel: channel,
+        message: {
+          body:
+            'Hello kbot! This is ' +
+            bot.myInfo().username +
+            ' saying hello from my device ' +
+            bot.myInfo().devicename,
+        },
+      }
+
+      bot
+        .chatSend(sendArg)
+        .then(() => {
+          console.log('Message sent!')
+        })
+        .catch(err => console.log('Message failed to send', err))
+    })
+    .catch(err => console.log(err))
+})

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -17,7 +17,7 @@ import type {
 
 type InitOptions = {|
   username: string,
-  paperkey: Buffer,
+  paperkey: string,
   verbose?: boolean,
 |}
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -47,10 +47,7 @@ class Bot {
   init(options: InitOptions): Promise<?string> {
     this._verbose = options.verbose || false
 
-    return keybaseExec({
-      args: ['oneshot', '--username', options.username],
-      stdinBuffer: options.paperkey,
-    }).then(() => {
+    return keybaseExec(['oneshot', '--username', options.username], options.paperkey).then(() => {
       return getKeybaseUsernameAndDevicename().then(currentDPair => {
         if (currentDPair) {
           this._dPair = currentDPair

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -17,7 +17,7 @@ import type {
 
 type InitOptions = {|
   username: string,
-  paperkey: string,
+  paperkey: Buffer,
   verbose?: boolean,
 |}
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -48,7 +48,8 @@ class Bot {
     this._verbose = options.verbose || false
 
     return keybaseExec({
-      args: ['oneshot', '--username', options.username, '--paperkey', options.paperkey],
+      args: ['oneshot', '--username', options.username],
+      stdinBuffer: options.paperkey,
     }).then(() => {
       return getKeybaseUsernameAndDevicename().then(currentDPair => {
         if (currentDPair) {

--- a/lib/keybase-exec.js
+++ b/lib/keybase-exec.js
@@ -1,18 +1,13 @@
 // @flow
 import {spawn} from 'child_process'
 
-type Params = {|
-  args: string[],
-  stdinBuffer?: Buffer,
-|}
-
-export default function keybaseExec(params: Params): Promise<?string> {
-  const child = spawn('keybase', params.args)
+export default function keybaseExec(args: string[], stdinBuffer?: Buffer): Promise<?string> {
+  const child = spawn('keybase', args)
   const outBuffers: Buffer[] = []
   let out: ?string = null
 
-  if (params.stdinBuffer) {
-    child.stdin.write(params.stdinBuffer)
+  if (stdinBuffer) {
+    child.stdin.write(stdinBuffer)
     child.stdin.end()
   }
 

--- a/lib/keybase-exec.js
+++ b/lib/keybase-exec.js
@@ -8,8 +8,8 @@ export default function keybaseExec(args: string[], stdinBuffer?: Buffer): Promi
 
   if (stdinBuffer) {
     child.stdin.write(stdinBuffer)
-    child.stdin.end()
   }
+  child.stdin.end()
 
   child.stdout.on('data', chunk => {
     outBuffers.push(chunk)


### PR DESCRIPTION
Closes #5. Some notes:
- I think it makes more sense for `keybaseExec` to take in its parameters via actual function parameters instead of a `Params` object. This was a pretty easy change since we're only using it in `init` right now.
- I was getting an issue with the bot expecting stdin if none was provided. My solution was to just always end the stream instead of only ending the stream if we write data in. I think better reflects the behavior we want.