### PR TITLE
Don't just get unread conversations in `check_for_unreads` demo

### DIFF
--- a/demos/check_for_unreads.js
+++ b/demos/check_for_unreads.js
@@ -8,7 +8,6 @@ async function main() {
     await bot.init({username: process.env.KB_USERNAME, paperkey: process.env.KB_PAPERKEY, verbose: false})
     const res = await bot.chatList({
       showErrors: true,
-      unreadOnly: true,
     })
     const unreadCount = res.conversations.filter(c => c.unread).length
     console.log(`You have ${unreadCount} unread conversations out of ${res.conversations.length} total`)

--- a/demos/check_for_unreads.js
+++ b/demos/check_for_unreads.js
@@ -8,7 +8,6 @@ async function main() {
     await bot.init({username: process.env.KB_USERNAME, paperkey: process.env.KB_PAPERKEY, verbose: false})
     const res = await bot.chatList({
       showErrors: true,
-      unreadOnly: true,
     })
     if (res) {
       const unreadCount = res.conversations.filter(c => c.unread).length

--- a/demos/check_for_unreads.js
+++ b/demos/check_for_unreads.js
@@ -8,9 +8,14 @@ async function main() {
     await bot.init({username: process.env.KB_USERNAME, paperkey: process.env.KB_PAPERKEY, verbose: false})
     const res = await bot.chatList({
       showErrors: true,
+      unreadOnly: true,
     })
-    const unreadCount = res.conversations.filter(c => c.unread).length
-    console.log(`You have ${unreadCount} unread conversations out of ${res.conversations.length} total`)
+    if (res) {
+      const unreadCount = res.conversations.filter(c => c.unread).length
+      console.log(`You have ${unreadCount} unread conversations out of ${res.conversations.length} total`)
+    } else {
+      console.log('You have no messages. Go chat with someone!')
+    }
   } catch (error) {
     console.error(error)
   } finally {

--- a/demos/check_for_unreads.js
+++ b/demos/check_for_unreads.js
@@ -1,17 +1,19 @@
 #!/usr/bin/env node
-const {Bot} = require('../index.js')
+const Bot = require('../index.js')
 
 async function main() {
   const bot = new Bot()
 
   try {
-    await bot.init({username: process.env.KB_USERNAME, paperkey: process.env.KB_PAPERKEY, verbose: false})
-    const res = await bot.chatList({
+    const username = process.env.KB_USERNAME
+    const paperkey = process.env.KB_PAPERKEY
+    await bot.init(username, paperkey)
+    const conversations = await bot.chat.list({
       showErrors: true,
     })
-    if (res) {
-      const unreadCount = res.conversations.filter(c => c.unread).length
-      console.log(`You have ${unreadCount} unread conversations out of ${res.conversations.length} total`)
+    if (conversations.length) {
+      const unreadCount = conversations.filter(c => c.unread).length
+      console.log(`You have ${unreadCount} unread conversations out of ${conversations.length} total`)
     } else {
       console.log('You have no messages. Go chat with someone!')
     }

--- a/lib/chat/index.js
+++ b/lib/chat/index.js
@@ -54,7 +54,7 @@ const runApiCommand = async (arg: ApiCommandArg): Promise<any> => {
  */
 export const list: List = async options => {
   const res = await runApiCommand({method: 'list', options})
-  return res.conversations
+  return res ? res.conversations || [] : []
 }
 
 /**


### PR DESCRIPTION
Since the demo filters unread conversations, we don't want just the unread messages from the service. It looks like the unread only option was only introduced when we updated the flow types #13.

I only realized this would be an issue when I ran this demo while having no unread messages – I got a type error for trying to run `filter` on `null`. Even with unread messages, though, the results aren't correct as `res.conversations.length` doesn't give the number of conversations, but just the ones with unread messages.

I also added a check in the rare case someone runs this on an account where there are no conversations (and `res` is thus `null`).