### PR TITLE
Only ignore root index.js for tooling

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,2 @@
-index.js
-index.js.map
+/index.js
+/index.js.map

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,6 @@
 [ignore]
-index.js
-index.js.map
+/index.js
+/index.js.map
 
 [include]
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,2 @@
-index.js
-index.js.map
+/index.js
+/index.js.map

--- a/lib/base/index.js
+++ b/lib/base/index.js
@@ -3,7 +3,7 @@ import {keybaseExec} from '../utils'
 import {withStore, actionInit} from '../store'
 import type {Store} from '../store/types'
 import type {DeviceUsernamePair} from '../types'
-import type {Init, MyInfo, Deinit} from './types'
+import type {Init} from './types'
 
 /**
  * @ignore

--- a/lib/chat/index.js
+++ b/lib/chat/index.js
@@ -1,4 +1,5 @@
 // @flow
+
 import {guardInitialized} from '../base'
 import {formatOptions, keybaseExec} from '../utils'
 import {CHAT_API_VERSION} from '../constants'

--- a/lib/chat/index.js
+++ b/lib/chat/index.js
@@ -13,12 +13,6 @@ import type {
   Delete,
   WatchChannelForNewMessage,
   WatchAllChannelsForNewMessages,
-  ChatListOptionals,
-  ChatSendOptionals,
-  ChatReadOptionals,
-  ChatDeleteOptionals,
-  ChatConversation,
-  ChatChannel,
 } from './types'
 
 const runApiCommand = async (arg: ApiCommandArg): Promise<any> => {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "husky": "^1.2.0",
     "lint-staged": "^8.1.0",
     "mathjs": "^5.2.3",
-    "prettier": "^1.15.2",
+    "prettier": "^1.15.3",
     "rollup": "^0.67.3",
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-node-resolve": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "flow-bin": "^0.86.0",
+    "flow-bin": "^0.87.0",
     "husky": "^1.2.0",
     "lint-staged": "^8.1.0",
     "mathjs": "^5.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3696,9 +3696,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.15.2:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.2.tgz#d31abe22afa4351efa14c7f8b94b58bb7452205e"
+prettier@^1.15.3:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.3.tgz#1feaac5bdd181237b54dbe65d874e02a1472786a"
+  integrity sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==
 
 pretty-format@^23.6.0:
   version "23.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2033,9 +2033,10 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
-flow-bin@^0.86.0:
-  version "0.86.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.86.0.tgz#153a28722b4dc13b7200c74b644dd4d9f4969a11"
+flow-bin@^0.87.0:
+  version "0.87.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.87.0.tgz#fab7f984d8cc767e93fa9eb01cf7d57ed744f19d"
+  integrity sha512-mnvBXXZkUp4y6A96bR5BHa3q1ioIIN2L10w5osxJqagAakTXFYZwjl0t9cT3y2aCEf1wnK6n91xgYypQS/Dqbw==
 
 flush-write-stream@^1.0.2:
   version "1.0.3"


### PR DESCRIPTION
This was driving me insane for about two hours when I realized prettier wasn't formatting my code.

A couple of index.js files were changed after I linted/prettified/type-checked them. I also version bumped flow and prettier.