### PR TITLE
Pass Keybase Service STDERR Back to Error Message

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,43 +9,53 @@ type ExecOptions = {|
   json?: boolean,
 |}
 
-export function keybaseExec(
+export const keybaseExec = (
   args: string[],
   options: ExecOptions = {stdinBuffer: undefined, onStdOut: undefined}
-): Promise<any> {
+): Promise<any> => {
   const child = spawn('keybase', args)
-  const outBuffers: Buffer[] = []
-  let out: ?string = null
+  const stdOutBuffer: Buffer[] = []
+  const stdErrBuffer: Buffer[] = []
 
   if (options.stdinBuffer) {
     child.stdin.write(options.stdinBuffer)
   }
   child.stdin.end()
 
-  const lineReader = readline.createInterface({input: child.stdout})
+  const lineReaderStdout = readline.createInterface({input: child.stdout})
+
+  // Use readline interface to parse each line (\n separated) when provided
+  // with onStdOut callback
   if (options.onStdOut) {
-    lineReader.on('line', options.onStdOut)
+    lineReaderStdout.on('line', options.onStdOut)
   } else {
     child.stdout.on('data', chunk => {
-      outBuffers.push(chunk)
+      stdOutBuffer.push(chunk)
     })
   }
 
+  // Capture STDERR and use as error message if needed
+  child.stderr.on('data', chunk => {
+    stdErrBuffer.push(chunk)
+  })
+
   return new Promise((resolve, reject) => {
     child.on('close', code => {
+      let finalStdOut: ?string = null
+      // Pass back
       if (code) {
-        reject(new Error(`exited with code ${code}`))
+        const errorMessage = Buffer.concat(stdErrBuffer).toString('utf8')
+        reject(new Error(errorMessage))
       } else {
-        const stdout = Buffer.concat(outBuffers).toString('utf8')
+        const stdout = Buffer.concat(stdOutBuffer).toString('utf8')
 
         try {
-          out = options.json ? JSON.parse(stdout) : stdout
+          finalStdOut = options.json ? JSON.parse(stdout) : stdout
         } catch (e) {
           reject(e)
         }
       }
-
-      resolve(out)
+      resolve(finalStdOut)
     })
   })
 }


### PR DESCRIPTION
This captures the STDERR from the child process (keybase service) and uses the result as the Error message for the library's return.

Closes #32 