### PR TITLE
recursive cleanup + keybaseHomeDir rename

### DIFF
--- a/lib/base/index.js
+++ b/lib/base/index.js
@@ -10,8 +10,8 @@ import type {Init, Deinit} from './types'
  * getCurrentUsernameAndDevicename returns { username, devicename } from keybase status -j
  */
 const getCurrentUsernameAndDevicename = async (store: Store): Promise<DeviceUsernamePair> => {
-  const {keybaseHomeDir} = store.getState()
-  const status = await keybaseExec(keybaseHomeDir, ['status', '--json'], {json: true})
+  const {homeDir} = store.getState()
+  const status = await keybaseExec(homeDir, ['status', '--json'], {json: true})
   if (status && status.Username && status.Device && status.Device.name) {
     return {username: status.Username, devicename: status.Device.name}
   } else {
@@ -69,14 +69,14 @@ const _init = (store: Store) => {
       throw new Error(`Please provide a paperkey to initialize the bot.`)
 
     const update = {
-      keybaseHomeDir: randomTempDir(),
+      homeDir: randomTempDir(),
     }
     store.dispatch(actionPreinit(update))
 
-    const {keybaseHomeDir} = store.getState()
-    await mkdir(keybaseHomeDir)
-    await keybaseServiceStartup(keybaseHomeDir)
-    await keybaseExec(keybaseHomeDir, ['oneshot', '--username', username], {stdinBuffer: paperkey})
+    const {homeDir} = store.getState()
+    await mkdir(homeDir)
+    await keybaseServiceStartup(homeDir)
+    await keybaseExec(homeDir, ['oneshot', '--username', username], {stdinBuffer: paperkey})
 
     const currentDPair = await getCurrentUsernameAndDevicename(store)
     if (currentDPair && currentDPair.username && currentDPair.devicename) {
@@ -106,13 +106,13 @@ const _deinit = (store: Store) => {
    *
    */
   const deinit: Deinit = async () => {
-    const {keybaseHomeDir} = store.getState()
-    await keybaseExec(keybaseHomeDir, ['logout'])
+    const {homeDir} = store.getState()
+    await keybaseExec(homeDir, ['logout'])
     console.log(
       `TODO: there is a bug in keybase on macOS where this is stopping all Keybase services. Uncomment next line when fixed.`
     )
-    // await keybaseExec(keybaseHomeDir, ['ctl stop'])
-    await rmdir(keybaseHomeDir)
+    // await keybaseExec(homeDir, ['ctl stop'])
+    await rmdir(homeDir)
   }
   return deinit
 }

--- a/lib/base/index.js
+++ b/lib/base/index.js
@@ -1,5 +1,5 @@
 // @flow
-import {keybaseExec, mkdir, rmdir, randomTempDir, keybaseServiceStartup} from '../utils'
+import {keybaseExec, mkdir, rmdirRecursive, randomTempDir, keybaseServiceStartup} from '../utils'
 import {withStore, actionInit, actionPreinit} from '../store'
 import type {Store} from '../store/types'
 import type {DeviceUsernamePair} from '../types'
@@ -11,7 +11,9 @@ import type {Init, Deinit} from './types'
  */
 const getCurrentUsernameAndDevicename = async (store: Store): Promise<DeviceUsernamePair> => {
   const {homeDir} = store.getState()
-  const status = await keybaseExec(homeDir, ['status', '--json'], {json: true})
+  const status = await keybaseExec(homeDir, ['status', '--json'], {
+    json: true,
+  })
   if (status && status.Username && status.Device && status.Device.name) {
     return {username: status.Username, devicename: status.Device.name}
   } else {
@@ -76,7 +78,9 @@ const _init = (store: Store) => {
     const {homeDir} = store.getState()
     await mkdir(homeDir)
     await keybaseServiceStartup(homeDir)
-    await keybaseExec(homeDir, ['oneshot', '--username', username], {stdinBuffer: paperkey})
+    await keybaseExec(homeDir, ['oneshot', '--username', username], {
+      stdinBuffer: paperkey,
+    })
 
     const currentDPair = await getCurrentUsernameAndDevicename(store)
     if (currentDPair && currentDPair.username && currentDPair.devicename) {
@@ -112,7 +116,7 @@ const _deinit = (store: Store) => {
       `TODO: there is a bug in keybase on macOS where this is stopping all Keybase services. Uncomment next line when fixed.`
     )
     // await keybaseExec(homeDir, ['ctl stop'])
-    await rmdir(homeDir)
+    await rmdirRecursive(homeDir)
   }
   return deinit
 }

--- a/lib/chat/index.js
+++ b/lib/chat/index.js
@@ -26,7 +26,7 @@ const runApiCommand = async (arg: ApiCommandArg): Promise<any> => {
   }
   const inputString = JSON.stringify(input)
   const size = inputString.length
-  const output = await keybaseExec(arg.keybaseHomeDir, ['chat', 'api'], {
+  const output = await keybaseExec(arg.homeDir, ['chat', 'api'], {
     stdinBuffer: Buffer.alloc(size, inputString, 'utf8'),
     json: true,
   })
@@ -49,8 +49,8 @@ const _list = (store: Store) => {
    *
    */
   const list: List = async options => {
-    const {keybaseHomeDir} = store.getState()
-    const res = await runApiCommand({method: 'list', options, keybaseHomeDir})
+    const {homeDir} = store.getState()
+    const res = await runApiCommand({method: 'list', options, homeDir})
     return res ? res.conversations || [] : []
   }
   return list
@@ -63,14 +63,14 @@ const _read = (store: Store) => {
    * @memberof bot.chat
    */
   const read: Read = async (channel, options) => {
-    const {keybaseHomeDir} = store.getState()
+    const {homeDir} = store.getState()
     const optionsWithDefaults = {
       ...options,
       channel,
       peek: options.peek !== undefined ? options.peek : false,
       unreadOnly: options.unreadOnly !== undefined ? options.unreadOnly : false,
     }
-    await runApiCommand({method: 'read', options: optionsWithDefaults, keybaseHomeDir})
+    await runApiCommand({method: 'read', options: optionsWithDefaults, homeDir})
   }
   return read
 }
@@ -87,8 +87,8 @@ const _send = (store: Store) => {
       channel,
       message,
     }
-    const {keybaseHomeDir} = store.getState()
-    const res = await runApiCommand({method: 'send', options: args, keybaseHomeDir})
+    const {homeDir} = store.getState()
+    const res = await runApiCommand({method: 'send', options: args, homeDir})
     if (!res) {
       throw new Error('keybase chat send returned nothing')
     }
@@ -117,8 +117,8 @@ const _deleteMessage = (store: Store) => {
       channel,
       messageId,
     }
-    const {keybaseHomeDir} = store.getState()
-    await runApiCommand({method: 'delete', options: args, keybaseHomeDir})
+    const {homeDir} = store.getState()
+    await runApiCommand({method: 'delete', options: args, homeDir})
   }
   return deleteMessage
 }
@@ -131,8 +131,8 @@ const _watchChannelForNewMessages = (store: Store) => {
    * @memberof bot.chat
    */
   const watchChannelForNewMessages: WatchChannelForNewMessage = (channel, onMessage) => {
-    const {keybaseHomeDir, username} = store.getState()
-    keybaseExec(keybaseHomeDir, ['chat', 'api-listen'], {
+    const {homeDir, username} = store.getState()
+    keybaseExec(homeDir, ['chat', 'api-listen'], {
       onStdOut: line => {
         try {
           const messageObject = JSON.parse(line)
@@ -186,8 +186,8 @@ const _watchAllChannelsForNewMessages = (store: Store) => {
    *
    */
   const watchAllChannelsForNewMessages: WatchAllChannelsForNewMessages = onMessage => {
-    const {keybaseHomeDir, username} = store.getState()
-    keybaseExec(keybaseHomeDir, ['chat', 'api-listen'], {
+    const {homeDir, username} = store.getState()
+    keybaseExec(homeDir, ['chat', 'api-listen'], {
       onStdOut: (line: string) => {
         try {
           const messageObject = JSON.parse(line)

--- a/lib/store/actions.js
+++ b/lib/store/actions.js
@@ -13,7 +13,7 @@ type Props = {|
 |}
 
 type PreinitProps = {|
-  keybaseHomeDir: string,
+  homeDir: string,
 |}
 
 export const actionInit = (props: Props): Action => ({

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -14,7 +14,7 @@ export const initialState = {
   initialized: false,
   username: undefined,
   devicename: undefined,
-  keybaseHomeDir: randomTempDir(),
+  homeDir: randomTempDir(),
   flags: {
     verbose: false,
   },

--- a/lib/store/reducer.js
+++ b/lib/store/reducer.js
@@ -26,7 +26,7 @@ export const reducer: Reducer = (state, action) => {
     case 'PREINIT': {
       return {
         ...state,
-        keybaseHomeDir: action.payload.keybaseHomeDir,
+        homeDir: action.payload.homeDir,
       }
     }
     default: {

--- a/lib/store/types.js
+++ b/lib/store/types.js
@@ -19,7 +19,7 @@ export type DeinitAction = {|
 export type PreinitAction = {|
   type: 'PREINIT',
   payload: {|
-    keybaseHomeDir: string,
+    homeDir: string,
   |},
 |}
 
@@ -29,7 +29,7 @@ export type State = {|
   +initialized: boolean,
   +username: void | string,
   +devicename: void | string,
-  +keybaseHomeDir: string,
+  +homeDir: string,
   +flags: {
     +verbose: boolean,
   },

--- a/lib/types.js
+++ b/lib/types.js
@@ -6,7 +6,7 @@ import type {AnyChatApi} from './chat/types'
 /**
  */
 export type DeviceUsernamePair = {|username: string, devicename: string|}
-export type ApiCommandArg = {|method: string, options: Object, keybaseHomeDir: string|}
+export type ApiCommandArg = {|method: string, options: Object, homeDir: string|}
 
 /*
  * Any Api Method

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,8 +18,8 @@ type ExecOptions = {|
 // it keeps a service running and acts on stderr, so let's not mess with the logical
 // complexity in keybaseExec
 //
-export function keybaseServiceStartup(keybaseHomeDir: string): Promise<void> {
-  const child = spawn('keybase', ['--home', keybaseHomeDir, 'service'])
+export function keybaseServiceStartup(homeDir: string): Promise<void> {
+  const child = spawn('keybase', ['--home', homeDir, 'service'])
   const lineReader = readline.createInterface({input: child.stderr})
   return new Promise((resolve, reject) => {
     child.on('close', code => {
@@ -36,11 +36,11 @@ export function keybaseServiceStartup(keybaseHomeDir: string): Promise<void> {
 }
 
 export const keybaseExec = (
-  keybaseHomeDir: string,
+  homeDir: string,
   args: string[],
   options: ExecOptions = {stdinBuffer: undefined, onStdOut: undefined}
 ): Promise<any> => {
-  const runArgs: string[] = ['--home', keybaseHomeDir, ...args]
+  const runArgs: string[] = ['--home', homeDir, ...args]
   const child = spawn('keybase', runArgs)
   const stdOutBuffer: Buffer[] = []
   const stdErrBuffer: Buffer[] = []

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,7 @@ import crypto from 'crypto'
 import snakeCase from 'lodash.snakecase'
 import {spawn} from 'child_process'
 import readline from 'readline'
+import {promisify} from 'util'
 
 type ExecOptions = {|
   stdinBuffer?: Buffer | string,
@@ -116,11 +117,26 @@ export function mkdir(dirName: string): Promise<void> {
   })
 }
 
-export function rmdir(dirName: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    // The keybase service will have made some files here; we want to clean them all out
-    // Node doesn't have a recursive dir clean, but.
-    console.log(`TODO: implement recurseive rmdir for tmp directory ${dirName}`)
-    resolve()
-  })
+export async function rmdirRecursive(dirName: string): Promise<void> {
+  const fsLstat = promisify(fs.lstat)
+  const fsUnlink = promisify(fs.unlink)
+  const fsRmdir = promisify(fs.rmdir)
+  const fsReaddir = promisify(fs.readdir)
+  try {
+    const dirStat = await fsLstat(dirName)
+    if (dirStat) {
+      for (const entry of await fsReaddir(dirName)) {
+        const entryPath = path.join(dirName, entry)
+        const stat = await fsLstat(entryPath)
+        if (stat.isDirectory()) {
+          await rmdirRecursive(entryPath)
+        } else {
+          await fsUnlink(entryPath)
+        }
+      }
+      await fsRmdir(dirName)
+    }
+  } catch (error) {
+    return error
+  }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -122,21 +122,17 @@ export async function rmdirRecursive(dirName: string): Promise<void> {
   const fsUnlink = promisify(fs.unlink)
   const fsRmdir = promisify(fs.rmdir)
   const fsReaddir = promisify(fs.readdir)
-  try {
-    const dirStat = await fsLstat(dirName)
-    if (dirStat) {
-      for (const entry of await fsReaddir(dirName)) {
-        const entryPath = path.join(dirName, entry)
-        const stat = await fsLstat(entryPath)
-        if (stat.isDirectory()) {
-          await rmdirRecursive(entryPath)
-        } else {
-          await fsUnlink(entryPath)
-        }
+  const dirStat = await fsLstat(dirName)
+  if (dirStat) {
+    for (const entry of await fsReaddir(dirName)) {
+      const entryPath = path.join(dirName, entry)
+      const stat = await fsLstat(entryPath)
+      if (stat.isDirectory()) {
+        await rmdirRecursive(entryPath)
+      } else {
+        await fsUnlink(entryPath)
       }
-      await fsRmdir(dirName)
     }
-  } catch (error) {
-    return error
+    await fsRmdir(dirName)
   }
 }


### PR DESCRIPTION
hi @nathunsmitty and @thebearjew - 

coupla things:

1. `keybaseHomeDir` -> `homeDir` , as requested.
2. I implemented a rmdir that cleans up all the levelDB and other crap that keybase makes. It works, although I wouldn't mind you taking a look at the function to give me feedback on ES6 code style escp. for async/await functions, which is all new to me. Here's the fn; I noticed that `util` coming with node 8+ comes with a promisify, so this all works without external deps. This kind of stuff sure is prettier in iced coffee script :-)

```javascript
export async function rmdirRecursive(dirName: string): Promise<void> {
  const fsLstat = promisify(fs.lstat)
  const fsUnlink = promisify(fs.unlink)
  const fsRmdir = promisify(fs.rmdir)
  const fsReaddir = promisify(fs.readdir)
  try {
    const dirStat = await fsLstat(dirName)
    if (dirStat) {
      for (const entry of await fsReaddir(dirName)) {
        const entryPath = path.join(dirName, entry)
        const stat = await fsLstat(entryPath)
        if (stat.isDirectory()) {
          await rmdirRecursive(entryPath)
        } else {
          await fsUnlink(entryPath)
        }
      }
      await fsRmdir(dirName)
    }
  } catch (error) {
    return error
  }
}
```
