### PR TITLE
test for team sends; cleanup other tests

### DIFF
--- a/__tests__/alice-init.test.js
+++ b/__tests__/alice-init.test.js
@@ -7,8 +7,8 @@ const alice = new Bot()
 
 async function main() {
   it(`alice can init()`, async () => {
-    await alice.init(config.alice1.username, config.alice1.paperkey)
-    expect(alice.myInfo().username).toBe(config.alice1.username)
+    await alice.init(config.bots.alice1.username, config.bots.alice1.paperkey)
+    expect(alice.myInfo().username).toBe(config.bots.alice1.username)
     await alice.deinit()
   })
 }

--- a/__tests__/shutdown.test.js
+++ b/__tests__/shutdown.test.js
@@ -33,7 +33,7 @@ async function countProcessesMentioning(substr) {
 }
 
 it(`alice can init and deinit()`, async () => {
-  await alice.init(config.alice1.username, config.alice1.paperkey)
+  await alice.init(config.bots.alice1.username, config.bots.alice1.paperkey)
   const homeDir = alice.myInfo().homeDir
 
   // make sure our bot can return a home directory

--- a/__tests__/team-hello.test.js
+++ b/__tests__/team-hello.test.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/* eslint-env jest */
+
+/*
+ * This bot loads 2 users from tests.config.js and fires up a bot for each one, simultaneusly,
+ * and they cumulatively count to 10; first `alice1` sends 1 to `bob1`, and then each one
+ * keeps adding 1 to the previous message.
+ */
+
+import Bot from '../lib/entry.js'
+import config from './tests.config.js'
+const alice = new Bot()
+const bob = new Bot()
+
+let ALICE_IS_SATISFIED = false
+let BOB_IS_SATISFIED = false
+
+async function startup() {
+  await alice.init(config.bots.alice1.username, config.bots.alice1.paperkey)
+  await bob.init(config.bots.bob1.username, config.bots.bob1.paperkey)
+  const channel = {
+    name: config.teams.acme.teamname,
+    public: false,
+    topic_type: 'chat',
+    members_type: 'team',
+    topic_name: 'general',
+  }
+  alice.chat.watchChannelForNewMessages(channel, message => {
+    if (message.content.type === 'text' && message.content.text.body === 'hello alice') {
+      ALICE_IS_SATISFIED = true
+    }
+  })
+  bob.chat.watchChannelForNewMessages(channel, message => {
+    if (message.content.type === 'text' && message.content.text.body === 'hello bob') {
+      BOB_IS_SATISFIED = true
+    }
+  })
+  await alice.chat.send(channel, {body: 'hello bob'})
+  await bob.chat.send(channel, {body: 'hello alice'})
+}
+
+async function shutDown() {
+  await alice.deinit()
+  await bob.deinit()
+}
+
+function waitAMoment(ms) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => resolve('done'), ms)
+  })
+}
+
+async function watchForCompletion() {
+  while (true) {
+    await waitAMoment(100)
+    if (ALICE_IS_SATISFIED && BOB_IS_SATISFIED) {
+      await shutDown()
+      return true
+    }
+  }
+}
+
+startup()
+
+it(`alice and bob can talk in a team channel`, async () => {
+  jest.setTimeout(15000)
+  await watchForCompletion()
+  return true
+})

--- a/__tests__/tests.config.example.js
+++ b/__tests__/tests.config.example.js
@@ -5,16 +5,23 @@
  */
 
 module.exports = {
-  alice1: {
-    username: 'alice',
-    paperkey: 'foo bar car...',
+  bots: {
+    alice1: {
+      username: 'alice',
+      paperkey: 'foo bar car...',
+    },
+    alice2: {
+      username: 'alice' /* should be the same as alice1 */,
+      paperkey: 'yo there paperkey...',
+    },
+    bob1: {
+      username: 'bob',
+      paperkey: 'one two three four...',
+    },
   },
-  alice2: {
-    username: 'alice' /* should be the same as alice1 */,
-    paperkey: 'yo there paperkey...',
-  },
-  bob1: {
-    username: 'bob',
-    paperkey: 'one two three four...',
+  teams: {
+    acme: {
+      teamname: 'someteam' /* a real team that you add your alice1, alice2, and bob1 all into */,
+    },
   },
 }


### PR DESCRIPTION
This adds a new test for sending and reading messge(s) in a team. It's roughly the same as sending in non-team chats, with a slightly different team structure.

The test config file changed slightly, so to get the tests to pass you'll need to edit your local `tests.config.js` file that you make out of `tests.config.example.js`. In particular it now also wants to know about a team.

also edited the alice1 and bob1 DM testing so they can count to 10 together with a unique code, in case there are other concurrent tests.
