### PR TITLE
Global test timeout fix

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@
   },
   "overrides": [
     {
-      "files": ["**/*.test.js"],
+      "files": ["**/*.test.js", "__tests__/*.js"],
       "env": {
         "jest": true
       }

--- a/__tests__/count-to-10.test.js
+++ b/__tests__/count-to-10.test.js
@@ -70,7 +70,6 @@ async function runTest() {
   // support running by hand or from jest
   if (typeof test !== 'undefined') {
     it(`can count to ${STOP_AT} with alice and bob`, async () => {
-      jest.setTimeout(30000)
       let done = false
       try {
         done = await watchForCompletion()

--- a/__tests__/setup.js
+++ b/__tests__/setup.js
@@ -1,0 +1,1 @@
+jest.setTimeout(30000)

--- a/__tests__/shutdown.test.js
+++ b/__tests__/shutdown.test.js
@@ -7,6 +7,8 @@ import config from './tests.config.js'
 const alice = new Bot()
 const exec = require('child_process').exec
 
+jest.setTimeout(30000)
+
 async function doesFileOrDirectoryExist(fpath) {
   try {
     await promisify(fs.lstat)(fpath)

--- a/__tests__/shutdown.test.js
+++ b/__tests__/shutdown.test.js
@@ -7,8 +7,6 @@ import config from './tests.config.js'
 const alice = new Bot()
 const exec = require('child_process').exec
 
-jest.setTimeout(30000)
-
 async function doesFileOrDirectoryExist(fpath) {
   try {
     await promisify(fs.lstat)(fpath)

--- a/__tests__/team-hello.test.js
+++ b/__tests__/team-hello.test.js
@@ -62,7 +62,7 @@ async function watchForCompletion() {
 startup()
 
 it(`alice and bob can talk in a team channel`, async () => {
-  jest.setTimeout(15000)
+  jest.setTimeout(30000)
   await watchForCompletion()
   return true
 })

--- a/__tests__/team-hello.test.js
+++ b/__tests__/team-hello.test.js
@@ -6,7 +6,7 @@
  * keeps adding 1 to the previous message.
  */
 
-import Bot from '../lib/entry.js'
+import Bot from '../lib'
 import config from './tests.config.js'
 const alice = new Bot()
 const bob = new Bot()

--- a/__tests__/team-hello.test.js
+++ b/__tests__/team-hello.test.js
@@ -62,7 +62,6 @@ async function watchForCompletion() {
 startup()
 
 it(`alice and bob can talk in a team channel`, async () => {
-  jest.setTimeout(30000)
   await watchForCompletion()
   return true
 })

--- a/jest.config.js
+++ b/jest.config.js
@@ -118,7 +118,7 @@ module.exports = {
   // setupFiles: [],
 
   // The path to a module that runs some code to configure or set up the testing framework before each test
-  setupTestFrameworkScriptFile: '__tests__/setup.js',
+  setupTestFrameworkScriptFile: '<rootDir>/__tests__/setup.js',
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
   // snapshotSerializers: [],

--- a/jest.config.js
+++ b/jest.config.js
@@ -118,7 +118,7 @@ module.exports = {
   // setupFiles: [],
 
   // The path to a module that runs some code to configure or set up the testing framework before each test
-  // setupTestFrameworkScriptFile: null,
+  setupTestFrameworkScriptFile: '__tests__/setup.js',
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
   // snapshotSerializers: [],


### PR DESCRIPTION
I think my computer may run a little slower than @malgorithms, since Jest always seems to give me timeout errors when I run our tests. This adds a config file and an upper timeout bound of 30 seconds, which I think should solve the problem for most computers.

Also fixed an import that I didn't catch in my last PR.