### PR TITLE
Add `onError` handler for watch methods (Closes #63)

### DIFF
--- a/demos/es7/math-bot-es7.js
+++ b/demos/es7/math-bot-es7.js
@@ -35,24 +35,20 @@ async function main() {
     const paperkey = process.env.KB_PAPERKEY
     await bot.init(username, paperkey)
     console.log('I am me!', bot.myInfo().username, bot.myInfo().devicename)
-
-    const onMessage = async message => {
-      try {
-        if (message.content.type === 'text') {
-          const prefix = message.content.text.body.slice(0, 6)
-          if (prefix === '/math ') {
-            const reply = {body: msgReply(message.content.text.body.slice(6))}
-            await bot.chat.send(message.channel, reply)
-          }
-        }
-      } catch (error) {
-        console.error(error)
-      }
-    }
-
     console.log('Beginning watch for new messages.')
     console.log(`Tell anyone to send a message to ${bot.myInfo().username} starting with '/math '`)
-    bot.chat.watchAllChannelsForNewMessages(onMessage)
+
+    const onMessage = async message => {
+      if (message.content.type === 'text') {
+        const prefix = message.content.text.body.slice(0, 6)
+        if (prefix === '/math ') {
+          const reply = {body: msgReply(message.content.text.body.slice(6))}
+          await bot.chat.send(message.channel, reply)
+        }
+      }
+    }
+    const onError = e => console.error(e)
+    bot.chat.watchAllChannelsForNewMessages(onMessage, onError)
   } catch (error) {
     console.error(error.message)
   }

--- a/demos/math-bot.js
+++ b/demos/math-bot.js
@@ -38,18 +38,17 @@ function main() {
       console.log('I am me!', bot.myInfo().username, bot.myInfo().devicename)
       console.log('Beginning watch for new messages.')
       console.log(`Tell anyone to send a message to ${bot.myInfo().username} starting with '/math '`)
-      bot.chat.watchAllChannelsForNewMessages(message => {
+      const onMessage = message => {
         if (message.content.type === 'text') {
           const prefix = message.content.text.body.slice(0, 6)
           if (prefix === '/math ') {
             const reply = {body: msgReply(message.content.text.body.slice(6))}
-            bot.chat.send(message.channel, reply).catch(error => {
-              console.error(error)
-              shutDown()
-            })
+            bot.chat.send(message.channel, reply)
           }
         }
-      })
+      }
+      const onError = e => console.error(e)
+      bot.chat.watchAllChannelsForNewMessages(onMessage, onError)
     })
     .catch(error => {
       console.error(error)

--- a/lib/chat/index.js
+++ b/lib/chat/index.js
@@ -123,19 +123,12 @@ class ChatBot extends BaseBot {
    * // reply to incoming traffic on all channels with 'thanks!'
    * const onMessage = message => {
    *   const channel = message.channel
-   *   bot.chat.send(
-   *     {
-   *       channel: channel,
-   *       message: {
-   *         body: 'thanks!!!',
-   *       },
-   *     },
-   *     (err, res) => {
-   *       if (err) {
-   *         console.error(err)
-   *       }
-   *     }
-   *   )
+   *   bot.chat.send({
+   *    channel: channel,
+   *      message: {
+   *        body: 'thanks!!!',
+   *      },
+   *   })
    * }
    * bot.chat.watchAllChannelsForNewMessages(onMessage)
    *

--- a/lib/chat/index.js
+++ b/lib/chat/index.js
@@ -13,6 +13,7 @@ import type {
   ChatReadOptions,
   ChatSendOptions,
   ChatDeleteOptions,
+  MessageNotification,
 } from './types'
 
 export type ApiCommandArg = {|method: string, options: Object, homeDir?: string|}
@@ -145,7 +146,7 @@ class ChatBot extends BaseBot {
     const lineReaderStdout = readline.createInterface({input: child.stdout})
     const onLine = (line: string) => {
       try {
-        const messageObject = JSON.parse(line)
+        const messageObject: MessageNotification = JSON.parse(line)
         if (messageObject.hasOwnProperty('error')) {
           throw new Error(messageObject.error)
         } else if (

--- a/lib/chat/index.js
+++ b/lib/chat/index.js
@@ -17,6 +17,8 @@ import type {
 
 export type ApiCommandArg = {|method: string, options: Object, homeDir?: string|}
 
+export type OnError = (error: Error) => void
+
 const runApiCommand = async (arg: ApiCommandArg): Promise<any> => {
   const options = formatOptions(arg.options)
   const input = {
@@ -101,28 +103,9 @@ class ChatBot extends BaseBot {
    * Listens for new chat messages on a specified channel. The `onMessage` function is called for every message your bot receives.
    * This is pretty similar to `watchAllChannelsForNewMessages`, except it specifically checks one channel.
    */
-  async watchChannelForNewMessages(channel: ChatChannel, onMessage: OnMessage) {
+  async watchChannelForNewMessages(channel: ChatChannel, onMessage: OnMessage, onError?: OnError) {
     await this._guardInitialized()
-    keybaseExec(this.homeDir, ['chat', 'api-listen'], {
-      onStdOut: line => {
-        try {
-          const messageObject = JSON.parse(line)
-          if (channel.name === messageObject.msg.channel.name) {
-            if (this.username && messageObject.msg.sender.username !== this.username.toLowerCase()) {
-              onMessage(messageObject.msg)
-            }
-          }
-        } catch (error) {
-          console.error(error)
-        }
-      },
-    }).catch(e => {
-      // for now we're dropping errors because this process
-      // closes with status when deinit happens, and we don't want to throw an error
-      // TODO: have something in bot's state that says it's ok to die, and if that isn't set,
-      // throw the error. This way we can distinguish between a failure to start the program
-      // and it dying on purpose
-    })
+    this._chatListen(onMessage, onError, channel)
   }
 
   /**
@@ -157,8 +140,12 @@ class ChatBot extends BaseBot {
    * bot.chat.watchAllChannelsForNewMessages(onMessage)
    *
    */
-  async watchAllChannelsForNewMessages(onMessage: OnMessage) {
+  async watchAllChannelsForNewMessages(onMessage: OnMessage, onError?: OnError) {
     await this._guardInitialized()
+    this._chatListen(onMessage, onError)
+  }
+
+  _chatListen(onMessage: OnMessage, onError?: OnError, channel?: ChatChannel) {
     const child = spawn('keybase', ['--home', this.homeDir, 'chat', 'api-listen'])
     this.spawnedProcesses.push(child)
 
@@ -166,11 +153,20 @@ class ChatBot extends BaseBot {
     const onLine = (line: string) => {
       try {
         const messageObject = JSON.parse(line)
-        if (this.username && messageObject.msg.sender.username !== this.username.toLowerCase()) {
+        if (messageObject.hasOwnProperty('error')) {
+          throw new Error(messageObject.error)
+        } else if (
+          // fire onMessage if you aren't the sender and if the message is in the right channel, if a channel is specified
+          ((channel && channel.name === messageObject.msg.channel.name) || !channel) &&
+          this.username &&
+          messageObject.msg.sender.username !== this.username.toLowerCase()
+        ) {
           onMessage(messageObject.msg)
         }
       } catch (error) {
-        console.error(error)
+        if (onError) {
+          onError(error)
+        }
       }
     }
     lineReaderStdout.on('line', onLine)

--- a/lib/chat/types.js
+++ b/lib/chat/types.js
@@ -15,14 +15,6 @@ type ChannelNameMention = {|
   convID: string,
 |}
 
-/**
- */
-export type ChatReadMessage = any
-
-/**
- */
-export type OnMessage = (message: ChatReadMessage) => void
-
 export type ChatChannel = {|
   name: string,
   public: boolean,
@@ -155,6 +147,10 @@ export type MessageNotification = {|
   error: string,
   pagination: Pagination,
 |}
+
+/**
+ */
+export type OnMessage = (message: MessageSummary) => void
 
 export type ChatOptionsSearch = {|
   maxHits: number,

--- a/lib/chat/types.js
+++ b/lib/chat/types.js
@@ -3,10 +3,17 @@
 /*
  * Keybase Chat JSON API V1 options
  * Source: https://github.com/keybase/client/blob/master/go/client/chat_api_handler.go
+ * https://github.com/keybase/client/blob/master/go/client/chat_svc_handler.go
+ * https://github.com/keybase/client/blob/master/go/protocol/chat1/local.go
  */
 
 type TopicType = 'chat' | 'DEV'
 type MembersType = 'team'
+type ChannelMention = 'none' | 'all' | 'here'
+type ChannelNameMention = {|
+  name: string,
+  convID: string,
+|}
 
 /**
  */
@@ -42,6 +49,111 @@ export type Pagination = {|
   next?: string,
   previous?: string,
   last?: string,
+|}
+
+export type TextContent = {|
+  type: 'text',
+  text: {|
+    body: string, // TODO: type this
+    payments: any[],
+  |},
+|}
+
+export type AttachmentContent = {|
+  type: 'attachment',
+  attachment: {|
+    object: any,
+    preview: any,
+    previews: any[],
+    metadata: any[],
+    uploaded: boolean,
+  |},
+|}
+
+export type ReactionContent = {|
+  type: 'reaction',
+  reaction: {|
+    m: string,
+    b: string,
+  |},
+|}
+
+export type EditContent = {|
+  type: 'edit',
+  edit: {|
+    messageID: number,
+    body: string,
+  |},
+|}
+
+/*
+  TODO contents:
+  Delete
+  Metadata
+  Headline
+  Attachmentuploaded
+  Join
+  Leave
+  System
+  Deletehistory
+  Sendpayment
+  Requestpayment
+  Unfurl
+
+  type ContentType =
+  | 'none'
+  | 'text'
+  | 'attachment'
+  | 'edit'
+  | 'delete'
+  | 'metadata'
+  | 'tlfname'
+  | 'headline'
+  | 'attachmentUploaded'
+  | 'join'
+  | 'leave'
+  | 'system'
+  | 'deleteHistory'
+  | 'reaction'
+  | 'sendPayment'
+  | 'requestPayment'
+  | 'unfurl'
+*/
+
+export type MessageContent = TextContent | AttachmentContent | ReactionContent | EditContent
+
+export type MessageSender = {|
+  username: string,
+  deviceName: string,
+|}
+
+export type MessageSummary = {|
+  id: number,
+  channel: ChatChannel,
+  sender: MessageSender,
+  sentAt: number,
+  sentAtMs: number,
+  content: MessageContent,
+  prev: any,
+  unread: boolean,
+  revokedDevice?: boolean,
+  offline?: boolean,
+  KBFSEncrypted?: boolean,
+  isEphemeral?: boolean,
+  isEphemeralExpired?: boolean,
+  ETime?: number,
+  reactions?: any[],
+  hasPairwiseMacs?: boolean,
+  atMentionUsernames?: string[],
+  channelMention?: ChannelMention,
+  channelNameMentions?: ChannelNameMention[],
+|}
+
+export type MessageNotification = {|
+  source: string,
+  msg: MessageSummary,
+  error: string,
+  pagination: Pagination,
 |}
 
 export type ChatOptionsSearch = {|


### PR DESCRIPTION
Better typing and error handling of chat notifications we get through `chat api-listen`. This was originally inspired by #63, but as I dug into I realized that case was just due us not properly parsing errors in notifications.

I didn't want to hide notifications completely since I think there are cases where they could be useful, hence the optional new `onError` parameter. If no `onError` is passed, all errors that occur in any notification body or in an `onMessage` callback will be silently caught. If an `onError` is specified, these errors will be handled by `onError`. If `onError` itself throws an error, then the watch method that it was passed to will throw that error, since that's probably indicative of something wrong in your code, not Keybase chat, and it doesn't make sense to have `onError` handle itself.