### PR TITLE
Add yarn configuration for exact types 

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+save-prefix ""


### PR DESCRIPTION
So something like
```
yarn add lodash.snakecase
```
results in
```
"dependencies": {
    "lodash.snakecase": "4.1.1"
  },
```
instead of
```
"dependencies": {
    "lodash.snakecase": "^4.1.1"
  },
```

This based off our decision in #60 and #61.